### PR TITLE
Use aiohttp for retrieving races, add a command_prefix kwarg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.egg-info
 __pycache__
+/.vscode

--- a/racetime_bot/handler.py
+++ b/racetime_bot/handler.py
@@ -13,7 +13,7 @@ class RaceHandler:
     # This is used by `should_stop` to determine when the handler should quit.
     stop_at = ['cancelled', 'finished']
 
-    def __init__(self, logger, conn, state):
+    def __init__(self, logger, conn, state, command_prefix='!'):
         """
         Base handler constructor.
 
@@ -35,6 +35,7 @@ class RaceHandler:
         self.data = {}
         self.logger = logger
         self.state = state
+        self.command_prefix = command_prefix
         self.ws = None
 
     def should_stop(self):
@@ -110,8 +111,8 @@ class RaceHandler:
             return
 
         words = message.get('message', '').lower().split(' ')
-        if words and words[0][0] == '!':
-            method = 'ex_' + words[0][1:]
+        if words and words[0].startswith(self.command_prefix.lower()):
+            method = 'ex_' + words[0][len(self.command_prefix):]
             args = words[1:]
             if hasattr(self, method):
                 self.logger.info('[%(race)s] Calling handler for %(word)s' % {

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     version='1.3.0',
     install_requires=[
         'asgiref',
+        'aiohttp',
         'requests',
         'websockets',
     ],


### PR DESCRIPTION
Firstly, I added add command_prefix kwarg to the command processor.  It defaults to "!"

Also, switched to aiohttp in the refresh_races loop instead of requests.  This lets token refreshes work asynchronously, which will prevent the bot from crashing if the request takes longer than normal to return.  The existing function that authorizes the bot still uses requests.

Feel free to reject this PR if you don't think aiohttp should be used here, I'll be happy to resubmit with just the command_prefix changes.