### PR TITLE
Ensure bot doesn't crash if RT.gg is down

### DIFF
--- a/racetime_bot/bot.py
+++ b/racetime_bot/bot.py
@@ -91,6 +91,7 @@ class Bot:
             'client_secret': self.client_secret,
             'grant_type': 'client_credentials',
         })
+        resp.raise_for_status()
         data = json.loads(resp.content)
         if not data.get('access_token'):
             raise Exception('Unable to retrieve access token.')
@@ -164,7 +165,8 @@ class Bot:
                 ) as resp:
                     data = json.loads(await resp.read())
             except Exception:
-                self.logger.error("Fatal error when attempting to retrieve race data.", exc_info=True)
+                self.logger.error(
+                    "Fatal error when attempting to retrieve race data.", exc_info=True)
                 await asyncio.sleep(self.scan_races_every)
                 continue
             self.races = {}
@@ -180,13 +182,16 @@ class Bot:
                         ) as resp:
                             race_data = json.loads(await resp.read())
                     except Exception:
-                        self.logger.error("Fatal error when attempting to retrieve race summary data.", exc_info=True)
+                        self.logger.error(
+                            "Fatal error when attempting to retrieve race summary data.", exc_info=True)
                         await asyncio.sleep(self.scan_races_every)
                         continue
                     if self.should_handle(race_data):
                         handler = self.create_handler(race_data)
-                        self.handlers[name] = self.loop.create_task(handler.handle())
-                        self.handlers[name].add_done_callback(partial(done, name))
+                        self.handlers[name] = self.loop.create_task(
+                            handler.handle())
+                        self.handlers[name].add_done_callback(
+                            partial(done, name))
                     else:
                         if name in self.state:
                             del self.state[name]

--- a/racetime_bot/bot.py
+++ b/racetime_bot/bot.py
@@ -183,8 +183,7 @@ class Bot:
                         ) as resp:
                             race_data = json.loads(await resp.read())
                     except Exception:
-                        self.logger.error(
-                            "Fatal error when attempting to retrieve race summary data.", exc_info=True)
+                        self.logger.error('Fatal error when attempting to retrieve race data.', exc_info=True)
                         await asyncio.sleep(self.scan_races_every)
                         continue
                     if self.should_handle(race_data):

--- a/racetime_bot/bot.py
+++ b/racetime_bot/bot.py
@@ -166,8 +166,7 @@ class Bot:
                 ) as resp:
                     data = json.loads(await resp.read())
             except Exception:
-                self.logger.error(
-                    "Fatal error when attempting to retrieve race data.", exc_info=True)
+                self.logger.error('Fatal error when attempting to retrieve race data.', exc_info=True)
                 await asyncio.sleep(self.scan_races_every)
                 continue
             self.races = {}

--- a/racetime_bot/bot.py
+++ b/racetime_bot/bot.py
@@ -191,10 +191,8 @@ class Bot:
                         continue
                     if self.should_handle(race_data):
                         handler = self.create_handler(race_data)
-                        self.handlers[name] = self.loop.create_task(
-                            handler.handle())
-                        self.handlers[name].add_done_callback(
-                            partial(done, name))
+                        self.handlers[name] = self.loop.create_task(handler.handle())
+                        self.handlers[name].add_done_callback(partial(done, name))
                     else:
                         if name in self.state:
                             del self.state[name]

--- a/racetime_bot/bot.py
+++ b/racetime_bot/bot.py
@@ -179,8 +179,7 @@ class Bot:
                     try:
                         async with aiohttp.request(
                                 method='get',
-                                url=self.http_uri(
-                                    summary_data.get('data_url')),
+                                url=self.http_uri(summary_data.get('data_url')),
                                 raise_for_status=True
                         ) as resp:
                             race_data = json.loads(await resp.read())

--- a/racetime_bot/bot.py
+++ b/racetime_bot/bot.py
@@ -183,7 +183,7 @@ class Bot:
                         ) as resp:
                             race_data = json.loads(await resp.read())
                     except Exception:
-                        self.logger.error('Fatal error when attempting to retrieve race data.', exc_info=True)
+                        self.logger.error('Fatal error when attempting to retrieve summary data.', exc_info=True)
                         await asyncio.sleep(self.scan_races_every)
                         continue
                     if self.should_handle(race_data):

--- a/racetime_bot/bot.py
+++ b/racetime_bot/bot.py
@@ -161,7 +161,8 @@ class Bot:
             try:
                 async with aiohttp.request(
                         method='get',
-                        url=self.http_uri(f'/{self.category_slug}/data')
+                        url=self.http_uri(f'/{self.category_slug}/data'),
+                        raise_for_status=True
                 ) as resp:
                     data = json.loads(await resp.read())
             except Exception:
@@ -178,7 +179,9 @@ class Bot:
                     try:
                         async with aiohttp.request(
                                 method='get',
-                                url=self.http_uri(summary_data.get('data_url'))
+                                url=self.http_uri(
+                                    summary_data.get('data_url')),
+                                raise_for_status=True
                         ) as resp:
                             race_data = json.loads(await resp.read())
                     except Exception:

--- a/racetime_bot/handler.py
+++ b/racetime_bot/handler.py
@@ -119,7 +119,11 @@ class RaceHandler:
                     'race': self.data.get('name'),
                     'word': words[0],
                 })
-                await getattr(self, method)(args, message)
+                try:
+                    await getattr(self, method)(args, message)
+                except Exception as e:
+                    self.logger.error('Command raised exception.', exc_info=True)
+
 
     async def race_data(self, data):
         """


### PR DESCRIPTION
Right now, the bot will die if a refresh_races gets a 4xx or 5xx response.

This helped with the stability of SahasrahBot when RT.gg got a little toasty from the ALTTPR quals.  Instead of trying to parse a 502 response as json, failing, and then the loop exiting it instead will just try again.  The real error is logged for future investigation if needed.

```
[2020-09-26 01:23:24,150] root (ERROR) :: Fatal error when attempting to retrieve race data.
Traceback (most recent call last):
  File "/mnt/d/Code/racetime-bot/racetime_bot/bot.py", line 162, in refresh_races
    async with aiohttp.request(
  File "/home/tprescott/git/sahasrahbot/env/lib/python3.8/site-packages/aiohttp/client.py", line 1051, in __aenter__
    self._resp = await self._coro
  File "/home/tprescott/git/sahasrahbot/env/lib/python3.8/site-packages/aiohttp/client.py", line 588, in _request
    resp.raise_for_status()
  File "/home/tprescott/git/sahasrahbot/env/lib/python3.8/site-packages/aiohttp/client_reqrep.py", line 941, in raise_for_status
    raise ClientResponseError(
aiohttp.client_exceptions.ClientResponseError: 502, message='Bad Gateway', url=URL('https://racetime.gg/smz3/data')
```