### PR TITLE
Fix default ssl context

### DIFF
--- a/racetime_bot/bot.py
+++ b/racetime_bot/bot.py
@@ -106,7 +106,7 @@ class Bot:
             extra_headers={
                 'Authorization': 'Bearer ' + self.access_token,
             },
-            ssl=self.ssl_context if self.ssl_context is not None else True,
+            ssl=self.ssl_context if self.ssl_context is not None else self.racetime_secure,
         )
 
         race_name = race_data.get('name')

--- a/racetime_bot/bot.py
+++ b/racetime_bot/bot.py
@@ -106,7 +106,7 @@ class Bot:
             extra_headers={
                 'Authorization': 'Bearer ' + self.access_token,
             },
-            ssl=self.ssl_context,
+            ssl=self.ssl_context if self.ssl_context else True,
         )
 
         race_name = race_data.get('name')

--- a/racetime_bot/bot.py
+++ b/racetime_bot/bot.py
@@ -106,7 +106,7 @@ class Bot:
             extra_headers={
                 'Authorization': 'Bearer ' + self.access_token,
             },
-            ssl=self.ssl_context if self.ssl_context else True,
+            ssl=self.ssl_context if self.ssl_context is not None else True,
         )
 
         race_name = race_data.get('name')


### PR DESCRIPTION
If it's set to None then SSL does not work, and None is the default. So, if ssl_context is set to None then I'm passing True to websockets instead.